### PR TITLE
Add GitHub action to automate deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy to DigitalOcean
+
+on:
+    push:
+        branches:
+        - main
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Checkout repo
+          uses: actions/checkout@v3
+
+        - name: Setup Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18'
+
+        - name: Install dependencies
+          run: npm install
+
+        - name: Build the app
+          run: npm run build
+
+        - name: Copy files to server
+          uses: appleboy/scp-action@v0.1.4
+          with:
+            host: ${{ secrets.DO_HOST }}
+            username: ${{ secrets.DO_USER }}
+            key: ${{ secrets.DO_SSH_KEY }}
+            source: "dist"
+            target: "${{ secrets.DEPLOY_TARGET_PATH }}temp-build"
+
+        - name: Rename and swap build folder via SSH
+          uses: appleboy/ssh-action@v0.1.8
+          with:
+            host: ${{ secrets.DO_HOST }}
+            username: ${{ secrets.DO_USER }}
+            key: ${{ secrets.DO_SSH_KEY }}
+            script: |
+                cd ${{ secrets.DEPLOY_TARGET_PATH }}
+                rm -rf 2025
+                mv temp-build/dist 2025
+                rm -rf temp-build


### PR DESCRIPTION
## Description
- The `deploy.yml` workflow will get triggered whenever something is merged to the `main` branch
- It will deploy the latest code to Digital Ocean

## Repository Environment Variables Required
- **DO_HOST**: Target Host IP of the droplet
  - `167.71.252.160` for hacknyu-static

- **DEPLOY_TARGET_PATH**
  - `/var/www/` for testing purposes
  - `/var/www/hacknyu.org/distributions/` for production

- **DO_USER**: username
  - `root` in our case

- **DO_SSH_KEY**: private SSH key of authenticated user

## How was this tested?
- Tested locally by using [act](https://github.com/nektos/act) command which simulates the GitHub workflow


https://github.com/user-attachments/assets/64f1a45a-b26e-4195-abf4-d4ecfe63b337